### PR TITLE
Fix mulitple `{{_lua:` patterns in same line

### DIFF
--- a/lua/template/init.lua
+++ b/lua/template/init.lua
@@ -45,7 +45,7 @@ local function expand_expr()
     '{{_email_}}',
     '{{_variable_}}',
     '{{_upper_file_}}',
-    '{{_lua:(.*)_}}',
+    '{{_lua:(.-)_}}',
     '{{_tomorrow_}}',
   }
 


### PR DESCRIPTION
non-greedy lua: pattern matching