### PR TITLE
Correctly implement cursor feature

### DIFF
--- a/lua/template/init.lua
+++ b/lua/template/init.lua
@@ -105,12 +105,12 @@ local function expand_expr()
     local cursor
     line = vim.deepcopy(line)
 
+    if line:find(expr[2]) then
+      cursor = true
+    end
+    
     for i, item in ipairs(expr) do
       line = expr_map[item](line)
-
-      if i == 2 then
-        cursor = true
-      end
     end
 
     return line, cursor


### PR DESCRIPTION
#43 fixed an issue with multiple occurrences of an expression on a line. However, it also broke the `{{_cursor_}}` functionality, since the `if i == 2` statement is always executed, so every line will return `cursor = true`. Thus, the cursor will end up at the bottom of the file regardless of where `{{_cursor_}}` is.

To fix this, I have moved the `cursor = true` line outside the loop and into an if statement. Please let me know if there are any issues.