### PR TITLE
update: example in vim.keymap to return ':template '

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ a rule of `tpl` template is you must set `;; filetype` in first line like a rust
 
 ```lua
 vim.keymap.set('n', '<Leader>t', function()
-    return ':Template '
+    vim.fn.feedkeys(':Template ')
 end, { remap = true})
 ```
 


### PR DESCRIPTION
Hello, this PR is simple. But it might be of help, because for some reason this previous example didn't work for neovim. I tested it on another machine and the same thing happened. Therefore, I would like to make this example more universal using `vim.fn.feedkeys()`, it returns as desired.